### PR TITLE
Rbac mapping and JWT token generation

### DIFF
--- a/common/auth-common/build.gradle.kts
+++ b/common/auth-common/build.gradle.kts
@@ -17,4 +17,8 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
+    
+    // YAML parsing for RBAC configuration
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
 }

--- a/common/auth-common/src/main/java/com/nibble/auth/JWTAuthenticationFilter.java
+++ b/common/auth-common/src/main/java/com/nibble/auth/JWTAuthenticationFilter.java
@@ -18,10 +18,10 @@ import java.util.stream.Collectors;
 
 public class JWTAuthenticationFilter extends OncePerRequestFilter {
 
-    private final String secretKey;
+    private final JwtService jwtService;
 
     public JWTAuthenticationFilter(String secretKey) {
-        this.secretKey = secretKey;
+        this.jwtService = new JwtService(secretKey, 86400000L);
     }
 
     @Override
@@ -33,7 +33,7 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
         }
         try {
             final String token = authHeader.substring(7);
-            final AuthenticatedUser user = JWTUtil.validateToken(token, secretKey);
+            final AuthenticatedUser user = jwtService.validateToken(token);
 
             final SecurityContext context = SecurityContextHolder.createEmptyContext();
             final List<GrantedAuthority> authorities = user.permissions().stream()

--- a/common/auth-common/src/main/java/com/nibble/auth/JwtService.java
+++ b/common/auth-common/src/main/java/com/nibble/auth/JwtService.java
@@ -7,12 +7,36 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 
 import javax.crypto.SecretKey;
+import java.time.Instant;
+import java.util.Date;
 import java.util.List;
 
-public  class JWTUtil {
+public class JwtService {
 
-    public static AuthenticatedUser validateToken(String token, String secretKey){
+    private final String secretKey;
+    private final long expirationMs;
 
+    public JwtService(String secretKey, long expirationMs) {
+        this.secretKey = secretKey;
+        this.expirationMs = expirationMs;
+    }
+
+    public String generateToken(TokenRequest request) {
+        final SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
+        final long now = Instant.now().toEpochMilli();
+        
+        return Jwts.builder()
+                .claim(JWTClaims.USER_ID, request.userId())
+                .claim(JWTClaims.EMAIL, request.email())
+                .claim(JWTClaims.ROLE, request.role())
+                .claim(JWTClaims.PERMISSIONS, request.permissions())
+                .issuedAt(new Date(now))
+                .expiration(new Date(now + expirationMs))
+                .signWith(key)
+                .compact();
+    }
+
+    public AuthenticatedUser validateToken(String token) {
         final SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey));
         final Jws<Claims> claimsJws = Jwts.parser()
                 .verifyWith(key)
@@ -29,7 +53,7 @@ public  class JWTUtil {
        return new AuthenticatedUser(userId,email,role,permissions);
     }
 
-    private static String getRequiredClaim(Claims claims, String claimName) {
+    private String getRequiredClaim(Claims claims, String claimName) {
         final String value = claims.get(claimName, String.class);
         if(value == null){
             throw new IllegalArgumentException("Missing required claim: " + claimName);
@@ -37,7 +61,7 @@ public  class JWTUtil {
         return value;
     }
 
-    private static List<String> getRequiredListClaim(Claims claims, String claimName) {
+    private List<String> getRequiredListClaim(Claims claims, String claimName) {
         final List<String> value = (List<String>) claims.get(claimName);
         if(value == null){
             throw new IllegalArgumentException("Missing required claim: " + claimName);

--- a/common/auth-common/src/main/java/com/nibble/auth/PermissionMapper.java
+++ b/common/auth-common/src/main/java/com/nibble/auth/PermissionMapper.java
@@ -1,0 +1,38 @@
+package com.nibble.auth;
+
+import com.nibble.auth.config.RbacConfigLoader;
+import com.nibble.auth.config.RoleDefinition;
+
+import java.util.Collections;
+import java.util.List;
+
+public class PermissionMapper {
+
+    public static List<String> getPermissionsForRole(Role role) {
+        if (role == null) {
+            throw new IllegalArgumentException("Role cannot be null");
+        }
+        
+        RoleDefinition roleDefinition = RbacConfigLoader.getConfig()
+                .roles()
+                .get(role.name());
+        
+        if (roleDefinition == null) {
+            throw new IllegalArgumentException("Role not found in RBAC configuration: " + role);
+        }
+        
+        List<String> permissions = roleDefinition.permissions();
+        return permissions != null ? Collections.unmodifiableList(permissions) : Collections.emptyList();
+    }
+
+    public static String getRoleDescription(Role role) {
+        RoleDefinition roleDefinition = RbacConfigLoader.getConfig()
+                .roles()
+                .get(role.name());
+        
+        return roleDefinition != null ? roleDefinition.description() : "Unknown role";
+    }
+    
+    private PermissionMapper() {
+    }
+}

--- a/common/auth-common/src/main/java/com/nibble/auth/Role.java
+++ b/common/auth-common/src/main/java/com/nibble/auth/Role.java
@@ -1,0 +1,7 @@
+package com.nibble.auth;
+
+public enum Role {
+    ADMIN,
+    USER,
+    SELLER
+}

--- a/common/auth-common/src/main/java/com/nibble/auth/TokenRequest.java
+++ b/common/auth-common/src/main/java/com/nibble/auth/TokenRequest.java
@@ -1,0 +1,11 @@
+package com.nibble.auth;
+
+import java.util.List;
+
+public record TokenRequest(
+    String userId,
+    String email,
+    String role,
+    List<String> permissions
+) {
+}

--- a/common/auth-common/src/main/java/com/nibble/auth/config/PermissionDefinition.java
+++ b/common/auth-common/src/main/java/com/nibble/auth/config/PermissionDefinition.java
@@ -1,0 +1,8 @@
+package com.nibble.auth.config;
+
+public record PermissionDefinition(
+    String name,
+    String description,
+    String category
+) {
+}

--- a/common/auth-common/src/main/java/com/nibble/auth/config/RbacConfig.java
+++ b/common/auth-common/src/main/java/com/nibble/auth/config/RbacConfig.java
@@ -1,0 +1,11 @@
+package com.nibble.auth.config;
+
+import java.util.List;
+import java.util.Map;
+
+public record RbacConfig(
+    String version,
+    List<PermissionDefinition> permissions,
+    Map<String, RoleDefinition> roles
+) {
+}

--- a/common/auth-common/src/main/java/com/nibble/auth/config/RbacConfigException.java
+++ b/common/auth-common/src/main/java/com/nibble/auth/config/RbacConfigException.java
@@ -1,0 +1,11 @@
+package com.nibble.auth.config;
+public class RbacConfigException extends RuntimeException {
+    
+    public RbacConfigException(String message) {
+        super(message);
+    }
+    
+    public RbacConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/common/auth-common/src/main/java/com/nibble/auth/config/RbacConfigLoader.java
+++ b/common/auth-common/src/main/java/com/nibble/auth/config/RbacConfigLoader.java
@@ -1,0 +1,56 @@
+package com.nibble.auth.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import java.io.InputStream;
+
+public class RbacConfigLoader {
+    
+    private static final String CONFIG_FILE = "rbac-config.yml";
+    private static RbacConfiguration configuration;
+    
+    static {
+        try {
+            loadConfiguration();
+        } catch (Exception e) {
+            throw new RbacConfigException("Failed to load RBAC configuration", e);
+        }
+    }
+
+    public static RbacConfig getConfig() {
+        return configuration.rbac();
+    }
+    
+    private static void loadConfiguration() {
+        InputStream inputStream = RbacConfigLoader.class.getClassLoader()
+                .getResourceAsStream(CONFIG_FILE);
+        
+        if (inputStream == null) {
+            throw new RbacConfigException("File not found: " + CONFIG_FILE);
+        }
+        
+        try {
+            ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+            configuration = mapper.readValue(inputStream, RbacConfiguration.class);
+            
+            if (configuration == null || configuration.rbac() == null) {
+                throw new RbacConfigException("Invalid configuration structure");
+            }
+        } catch (Exception e) {
+            throw new RbacConfigException("Failed to parse YAML configuration", e);
+        }
+    }
+    
+    public static boolean isValidPermission(String permissionName) {
+        return getConfig().permissions().stream()
+                .anyMatch(p -> p.name().equals(permissionName));
+    }
+    
+    public static boolean isValidRole(String roleName) {
+        return getConfig().roles().containsKey(roleName);
+    }
+    
+    private RbacConfigLoader() {
+    }
+}

--- a/common/auth-common/src/main/java/com/nibble/auth/config/RbacConfiguration.java
+++ b/common/auth-common/src/main/java/com/nibble/auth/config/RbacConfiguration.java
@@ -1,0 +1,4 @@
+package com.nibble.auth.config;
+
+public record RbacConfiguration(RbacConfig rbac) {
+}

--- a/common/auth-common/src/main/java/com/nibble/auth/config/RoleDefinition.java
+++ b/common/auth-common/src/main/java/com/nibble/auth/config/RoleDefinition.java
@@ -1,0 +1,9 @@
+package com.nibble.auth.config;
+
+import java.util.List;
+
+public record RoleDefinition(
+    String description,
+    List<String> permissions
+) {
+}

--- a/services/user-service/build.gradle.kts
+++ b/services/user-service/build.gradle.kts
@@ -9,8 +9,7 @@ dependencies{
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("com.h2database:h2")
-    // Dependency on auth-commons library
-//    implementation(project(":common:auth-common"))
+    implementation(project(":common:auth-common"))
     
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")

--- a/services/user-service/src/main/java/com/nibble/userservice/controller/UserLoginController.java
+++ b/services/user-service/src/main/java/com/nibble/userservice/controller/UserLoginController.java
@@ -1,5 +1,6 @@
 package com.nibble.userservice.controller;
 
+import com.nibble.userservice.dto.LoginResponse;
 import com.nibble.userservice.service.UserServiceImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,20 +18,14 @@ public class UserLoginController {
     private final UserServiceImpl userService;
 
     @GetMapping("/")
-    public ResponseEntity<String> home(@AuthenticationPrincipal OidcUser user) {
+    public ResponseEntity<LoginResponse> home(@AuthenticationPrincipal OidcUser user) {
         log.info("User authenticated: {}", user.getEmail());
 
         String email = user.getEmail();
         String username = user.getGivenName();
-        String message;
-        if (userService.isExistingUser(email, username)) {
-            message = "Welcome back, " + username + "!";
-        } else {
-            userService.save(email, username);
-            message = "Welcome to Nibble, " + username + "!";
-        }
-
-        return ResponseEntity.ok(message);
+        
+        LoginResponse loginResponse = userService.generateLoginResponse(email, username);
+        return ResponseEntity.ok(loginResponse);
     }
 
 }

--- a/services/user-service/src/main/java/com/nibble/userservice/controller/UserLoginController.java
+++ b/services/user-service/src/main/java/com/nibble/userservice/controller/UserLoginController.java
@@ -22,7 +22,15 @@ public class UserLoginController {
 
         String email = user.getEmail();
         String username = user.getGivenName();
-        return ResponseEntity.ok(userService.saveOrUpdate(email, username));
+        String message;
+        if (userService.isExistingUser(email, username)) {
+            message = "Welcome back, " + username + "!";
+        } else {
+            userService.save(email, username);
+            message = "Welcome to Nibble, " + username + "!";
+        }
+
+        return ResponseEntity.ok(message);
     }
 
 }

--- a/services/user-service/src/main/java/com/nibble/userservice/dto/LoginResponse.java
+++ b/services/user-service/src/main/java/com/nibble/userservice/dto/LoginResponse.java
@@ -1,0 +1,4 @@
+package com.nibble.userservice.dto;
+
+public record LoginResponse(String token, String email, String username, String role) {
+}

--- a/services/user-service/src/main/java/com/nibble/userservice/entity/User.java
+++ b/services/user-service/src/main/java/com/nibble/userservice/entity/User.java
@@ -1,5 +1,6 @@
 package com.nibble.userservice.entity;
 
+import com.nibble.auth.Role;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -24,6 +25,10 @@ public class User {
     @Column(nullable = false)
     private String username;
     
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role = Role.USER; // Default role: customer
+    
     @Column(name = "created_at")
     private LocalDateTime createdAt;
     
@@ -40,10 +45,19 @@ public class User {
     protected void onUpdate() {
         lastLogin = LocalDateTime.now();
     }
-    
+
     public User(String email, String username) {
         this.email = email;
         this.username = username;
+        this.role = Role.USER;
+        this.createdAt = LocalDateTime.now();
+        this.lastLogin = LocalDateTime.now();
+    }
+
+    public User(String email, String username, Role role) {
+        this.email = email;
+        this.username = username;
+        this.role = role;
         this.createdAt = LocalDateTime.now();
         this.lastLogin = LocalDateTime.now();
     }

--- a/services/user-service/src/main/java/com/nibble/userservice/service/UserService.java
+++ b/services/user-service/src/main/java/com/nibble/userservice/service/UserService.java
@@ -1,5 +1,6 @@
 package com.nibble.userservice.service;
 
 public interface UserService {
-    String saveOrUpdate(String email, String username);
+    void save(String email, String username);
+    boolean isExistingUser(String email, String username);
 }

--- a/services/user-service/src/main/java/com/nibble/userservice/service/UserServiceImpl.java
+++ b/services/user-service/src/main/java/com/nibble/userservice/service/UserServiceImpl.java
@@ -1,11 +1,16 @@
 package com.nibble.userservice.service;
 
+import com.nibble.auth.JwtService;
+import com.nibble.auth.PermissionMapper;
+import com.nibble.auth.TokenRequest;
+import com.nibble.userservice.dto.LoginResponse;
 import com.nibble.userservice.entity.User;
 import com.nibble.userservice.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -14,6 +19,7 @@ import java.util.Optional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final JwtService jwtService;
 
     @Override
     public void save(String email, String username) {
@@ -26,6 +32,25 @@ public class UserServiceImpl implements UserService {
         final Optional<User> existingUser = userRepository.findByEmail(email);
         return existingUser.isPresent();
     }
+    
+    public LoginResponse generateLoginResponse(String email, String username) {
+        User user = userRepository.findByEmail(email)
+                .orElseGet(() -> {
+                    User newUser = new User(email, username);
+                    return userRepository.save(newUser);
+                });
+        
+        List<String> permissions = PermissionMapper.getPermissionsForRole(user.getRole());
+        
+        TokenRequest tokenRequest = new TokenRequest(
+                user.getId().toString(),
+                user.getEmail(),
+                user.getRole().name(),
+                permissions
+        );
+        
+        String token = jwtService.generateToken(tokenRequest);
+        
+        return new LoginResponse(token, user.getEmail(), user.getUsername(), user.getRole().name());
+    }
 }
-
-

--- a/services/user-service/src/main/java/com/nibble/userservice/service/UserServiceImpl.java
+++ b/services/user-service/src/main/java/com/nibble/userservice/service/UserServiceImpl.java
@@ -16,23 +16,13 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
 
     @Override
-    public String saveOrUpdate(String email, String username) {
-        String message;
-        if (isExistingUser(email, username)) {
-            message = "Welcome back, " + username + "!";
-        } else {
-            save(email, username);
-            message = "Welcome to Nibble, " + username + "!";
-        }
-        return message;
-    }
-
-    private void save(String email, String username) {
+    public void save(String email, String username) {
         final User newUser = new User(email, username);
         userRepository.save(newUser);
     }
 
-    private boolean isExistingUser(String email, String username) {
+    @Override
+    public boolean isExistingUser(String email, String username) {
         final Optional<User> existingUser = userRepository.findByEmail(email);
         return existingUser.isPresent();
     }


### PR DESCRIPTION
## Changes
Implemented JWT token generation with role-based access control using YAML configuration for easy permission management.


### Authentication Library

- Created YAML configuration file defining 3 roles and 18 granular permissions
- Added permission mapper to retrieve role-based permissions from YAML
- Refactored JWT utilities to use constructor injection pattern
- Defined roles and permissions as enums for type safety
- 
### User Service

- Updated user entity to use shared role definitions
- Implemented token generation with role-based permissions from YAML config
- Modified login endpoint to return JWT token after OAuth2 authentication